### PR TITLE
fix(eth): add shims dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-sqs": "^3.315.0",
     "@aws-sdk/lib-storage": "^3.315.0",
     "@aws-sdk/s3-request-presigner": "^3.315.0",
+    "@ethersproject/shims": "^5.7.0",
     "@fastify/cors": "^8.1.0",
     "@fastify/formbody": "^7.3.0",
     "@fastify/helmet": "^10.0.1",

--- a/src/utils/blockchain/ethereum.ts
+++ b/src/utils/blockchain/ethereum.ts
@@ -1,3 +1,5 @@
+import "@ethersproject/shims";
+
 import { ethers } from "ethers";
 
 import { BlockchainAddressType, BlockchainService } from "./generic";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,6 +1915,11 @@
     "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
+"@ethersproject/shims@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/shims/-/shims-5.7.0.tgz#ee32e543418595774029c5ea6123ea8995e7e154"
+  integrity sha512-WeDptc6oAprov5CCN2LJ/6/+dC9gTonnkdAtLepm/7P5Z+3PRxS5NpfVWmOMs1yE4Vitl2cU8bOPWC0GvGSbVg==
+
 "@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"


### PR DESCRIPTION
- Hay un problema con el env de stg que no deja crear addresses en el mock de okex. Ref [Issue](https://github.com/ethers-io/ethers.js/issues/1118)
- ethers tiene estos `shims` que son justamente para envs que no tienen una `secure random source`
- No lo puedo reproducir local porque es un tema de env, pero creo que deberia ser el fix, si no lo soluciona revierto.